### PR TITLE
fix: Work around lua_ls not showing hints on load

### DIFF
--- a/lua/inlay-hints/utils.lua
+++ b/lua/inlay-hints/utils.lua
@@ -30,11 +30,22 @@ local function setup_inlay_hints(client, bufnr)
   if vim.b[bufnr].inlay_hints_enabled then
     return
   end
-  vim.b[bufnr].inlay_hints_enabled = true
 
-  pcall(function()
-    vim.lsp.inlay_hint.enable(true, { bufnr = bufnr })
-  end)
+  local function setup_inlay_hints_impl()
+    vim.b[bufnr].inlay_hints_enabled = true
+
+    pcall(function()
+      vim.lsp.inlay_hint.enable(true, { bufnr = bufnr })
+    end)
+  end
+
+  if client.name == "lua_ls" then
+    -- Work around a lua_ls bug.
+    -- Without this, inlay hints don't appear until scrolling or editing.
+    vim.defer_fn(setup_inlay_hints_impl, 500)
+  else
+    setup_inlay_hints_impl()
+  end
 end
 
 ---@param args table


### PR DESCRIPTION
lua_ls has a bug where scrolling or editing the file is needed to see inlay hints. Delaying the enablement somehow fixes this.

I filed a bug upstream at https://github.com/LuaLS/lua-language-server/issues/3344.

# Before

No inlay hints on Lua files appear before scrolling:

<img width="2230" height="1579" alt="utils.lua no inlay hints before scroll" src="https://github.com/user-attachments/assets/e0ec55c8-5e37-4225-bbf1-9116a6e6bead" />

<img width="2033" height="1584" alt="utils.lua inlay hints only after scroll" src="https://github.com/user-attachments/assets/bfbf933b-50b8-4118-b119-1c6eeb750b54" />

# After

Inlay hints appear even before scrolling.

<img width="2258" height="1588" alt="utils.lua inlay hints even before scroll" src="https://github.com/user-attachments/assets/3dea97a1-1c42-4ce5-b78e-bc1d0936fe63" />
